### PR TITLE
Add suffix style support

### DIFF
--- a/seqeval/metrics/sequence_labeling.py
+++ b/seqeval/metrics/sequence_labeling.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 import numpy as np
 
 
-def get_entities(seq):
+def get_entities(seq, suffix=False):
     """Gets entities from sequence.
 
     Args:
@@ -36,8 +36,12 @@ def get_entities(seq):
     begin_offset = 0
     chunks = []
     for i, chunk in enumerate(seq + ['O']):
-        tag = chunk[0]
-        type_ = chunk.split('-')[-1]
+        if suffix:
+            tag = chunk[-1]
+            type_ = chunk.split('-')[0]
+        else:
+            tag = chunk[0]
+            type_ = chunk.split('-')[-1]
 
         if end_of_chunk(prev_tag, tag, prev_type, type_):
             chunks.append((prev_type, begin_offset, i-1))

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -22,6 +22,10 @@ class TestMetrics(unittest.TestCase):
         y_true = ['O', 'O', 'O', 'B-MISC', 'I-MISC', 'I-MISC', 'O', 'B-PER', 'I-PER']
         self.assertEqual(get_entities(y_true), [('MISC', 3, 5), ('PER', 7, 8)])
 
+    def test_get_entities_with_suffix_style(self):
+        y_true = ['O', 'O', 'O', 'MISC-B', 'MISC-I', 'MISC-I', 'O', 'PER-B', 'PER-I']
+        self.assertEqual(get_entities(y_true, suffix=True), [('MISC', 3, 5), ('PER', 7, 8)])
+
     def test_classification_report(self):
         print(classification_report(self.y_true, self.y_pred))
 


### PR DESCRIPTION
Thanks for sharing a awesome tool for general purpose sequence labeling!

In some corpora, BIO information is located on the end of a label.
(e.g. http://www.ar.media.kyoto-u.ac.jp/data/recipe/)
So I think it would be better to support them.