### PR TITLE
Add scoring criteria

### DIFF
--- a/seqeval/metrics/sequence_labeling.py
+++ b/seqeval/metrics/sequence_labeling.py
@@ -18,7 +18,7 @@ def get_entities(seq, criteria='exact', suffix=False):
     Args:
         seq (list): sequence of labels.
         criteria (str): Optional, criteria which will be used for evaluation.
-            'exact' matches boundaries  directly, 'left' requires only a left
+            'exact' matches boundaries exactly, 'left' requires only a left
             boundary match and 'right' requires only a right boundary match.
             Defaults to 'exact'.
 
@@ -142,7 +142,7 @@ def f1_score(y_true, y_pred, average='micro', criteria='exact', suffix=False):
         y_true : 2d array. Ground truth (correct) target values.
         y_pred : 2d array. Estimated targets as returned by a tagger.
         criteria (str): Optional, criteria which will be used for evaluation.
-            'exact' matches boundaries  directly, 'left' requires only a left
+            'exact' matches boundaries exactly, 'left' requires only a left
             boundary match and 'right' requires only a right boundary match.
             Defaults to 'exact'.
 
@@ -221,7 +221,7 @@ def precision_score(y_true, y_pred, average='micro', criteria='exact', suffix=Fa
         y_true : 2d array. Ground truth (correct) target values.
         y_pred : 2d array. Estimated targets as returned by a tagger.
         criteria (str): Optional, criteria which will be used for evaluation.
-            'exact' matches boundaries  directly, 'left' requires only a left
+            'exact' matches boundaries exactly, 'left' requires only a left
             boundary match and 'right' requires only a right boundary match.
             Defaults to 'exact'.
 
@@ -264,7 +264,7 @@ def recall_score(y_true, y_pred, average='micro', criteria='exact', suffix=False
         y_true : 2d array. Ground truth (correct) target values.
         y_pred : 2d array. Estimated targets as returned by a tagger.
         criteria (str): Optional, criteria which will be used for evaluation.
-            'exact' matches boundaries  directly, 'left' requires only a left
+            'exact' matches boundaries exactly, 'left' requires only a left
             boundary match and 'right' requires only a right boundary match.
             Defaults to 'exact'.
 
@@ -335,7 +335,7 @@ def classification_report(y_true, y_pred, digits=2, criteria='exact', suffix=Fal
         y_pred : 2d array. Estimated targets as returned by a classifier.
         digits : int. Number of digits for formatting output floating point values.
         criteria (str): Optional, criteria which will be used for evaluation.
-            'exact' matches boundaries  directly, 'left' requires only a left
+            'exact' matches boundaries exactly, 'left' requires only a left
             boundary match and 'right' requires only a right boundary match.
             Defaults to 'exact'.
 

--- a/seqeval/metrics/sequence_labeling.py
+++ b/seqeval/metrics/sequence_labeling.py
@@ -25,6 +25,9 @@ def get_entities(seq, criteria='exact', suffix=False):
     Returns:
         list: list of (chunk_type, chunk_start, chunk_end).
 
+    Raises:
+        ValueError, if `criteria` is not one of 'exact', 'left', or 'right'.
+
     Example:
         >>> from seqeval.metrics.sequence_labeling import get_entities
         >>> seq = ['B-PER', 'I-PER', 'O', 'B-LOC']
@@ -149,6 +152,9 @@ def f1_score(y_true, y_pred, average='micro', criteria='exact', suffix=False):
     Returns:
         score : float.
 
+    Raises:
+        ValueError, if `criteria` is not one of 'exact', 'left', or 'right'.
+
     Example:
         >>> from seqeval.metrics import f1_score
         >>> y_true = [['O', 'O', 'O', 'B-MISC', 'I-MISC', 'I-MISC', 'O'], ['B-PER', 'I-PER', 'O']]
@@ -228,6 +234,9 @@ def precision_score(y_true, y_pred, average='micro', criteria='exact', suffix=Fa
     Returns:
         score : float.
 
+    Raises:
+        ValueError, if `criteria` is not one of 'exact', 'left', or 'right'.
+
     Example:
         >>> from seqeval.metrics import precision_score
         >>> y_true = [['O', 'O', 'O', 'B-MISC', 'I-MISC', 'I-MISC', 'O'], ['B-PER', 'I-PER', 'O']]
@@ -271,6 +280,9 @@ def recall_score(y_true, y_pred, average='micro', criteria='exact', suffix=False
     Returns:
         score : float.
 
+    Raises:
+        ValueError, if `criteria` is not one of 'exact', 'left', or 'right'.
+
     Example:
         >>> from seqeval.metrics import recall_score
         >>> y_true = [['O', 'O', 'O', 'B-MISC', 'I-MISC', 'I-MISC', 'O'], ['B-PER', 'I-PER', 'O']]
@@ -280,7 +292,7 @@ def recall_score(y_true, y_pred, average='micro', criteria='exact', suffix=False
     """
     if criteria not in ['exact', 'left', 'right']:
         err_msg = ("Expected criteria to be one of 'exact', 'left', or 'right'."
-                    " Got: {}").format(criteria)
+                   " Got: {}").format(criteria)
         raise ValueError(err_msg)
 
     true_entities = set(get_entities(y_true, criteria, suffix))
@@ -317,12 +329,12 @@ def performance_measure(y_true, y_pred):
         y_true = [item for sublist in y_true for item in sublist]
         y_pred = [item for sublist in y_pred for item in sublist]
     performance_dict['TP'] = sum(y_t == y_p for y_t, y_p in zip(y_true, y_pred)
-                                if ((y_t != 'O') or (y_p != 'O')))
+                                 if ((y_t != 'O') or (y_p != 'O')))
     performance_dict['FP'] = sum(y_t != y_p for y_t, y_p in zip(y_true, y_pred))
     performance_dict['FN'] = sum(((y_t != 'O') and (y_p == 'O'))
-                                for y_t, y_p in zip(y_true, y_pred))
+                                 for y_t, y_p in zip(y_true, y_pred))
     performance_dict['TN'] = sum((y_t == y_p == 'O')
-                                for y_t, y_p in zip(y_true, y_pred))
+                                 for y_t, y_p in zip(y_true, y_pred))
 
     return performance_dict
 
@@ -341,6 +353,9 @@ def classification_report(y_true, y_pred, digits=2, criteria='exact', suffix=Fal
 
     Returns:
         report : string. Text summary of the precision, recall, F1 score for each class.
+
+    Raises:
+        ValueError, if `criteria` is not one of 'exact', 'left', or 'right'.
 
     Examples:
         >>> from seqeval.metrics import classification_report

--- a/seqeval/metrics/sequence_labeling.py
+++ b/seqeval/metrics/sequence_labeling.py
@@ -312,19 +312,19 @@ def performance_measure(y_true, y_pred):
         >>> performance_measure(y_true, y_pred)
         (3, 3, 1, 4)
     """
-    performace_dict = dict()
+    performance_dict = dict()
     if any(isinstance(s, list) for s in y_true):
         y_true = [item for sublist in y_true for item in sublist]
         y_pred = [item for sublist in y_pred for item in sublist]
-    performace_dict['TP'] = sum(y_t == y_p for y_t, y_p in zip(y_true, y_pred)
+    performance_dict['TP'] = sum(y_t == y_p for y_t, y_p in zip(y_true, y_pred)
                                 if ((y_t != 'O') or (y_p != 'O')))
-    performace_dict['FP'] = sum(y_t != y_p for y_t, y_p in zip(y_true, y_pred))
-    performace_dict['FN'] = sum(((y_t != 'O') and (y_p == 'O'))
+    performance_dict['FP'] = sum(y_t != y_p for y_t, y_p in zip(y_true, y_pred))
+    performance_dict['FN'] = sum(((y_t != 'O') and (y_p == 'O'))
                                 for y_t, y_p in zip(y_true, y_pred))
-    performace_dict['TN'] = sum((y_t == y_p == 'O')
+    performance_dict['TN'] = sum((y_t == y_p == 'O')
                                 for y_t, y_p in zip(y_true, y_pred))
 
-    return performace_dict
+    return performance_dict
 
 
 def classification_report(y_true, y_pred, digits=2, criteria='exact', suffix=False):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -34,11 +34,11 @@ class TestMetrics(unittest.TestCase):
     def test_get_entities_with_criteria_exact(self):
         y_true = ['O', 'O', 'O', 'B-MISC', 'I-MISC', 'I-MISC', 'O', 'B-PER', 'I-PER']
         self.assertEqual(get_entities(y_true), [('MISC', 3, 5), ('PER', 7, 8)])
-    
+
     def test_get_entities_with_criteria_left(self):
         y_true = ['O', 'O', 'O', 'B-MISC', 'I-MISC', 'I-MISC', 'O', 'B-PER', 'I-PER']
         self.assertEqual(get_entities(y_true, criteria='left'), [('MISC', 3), ('PER', 7)])
-    
+
     def test_get_entities_with_criteria_right(self):
         y_true = ['O', 'O', 'O', 'B-MISC', 'I-MISC', 'I-MISC', 'O', 'B-PER', 'I-PER']
         self.assertEqual(get_entities(y_true, criteria='left'), [('MISC', 5), ('PER', 8)])

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -31,9 +31,17 @@ class TestMetrics(unittest.TestCase):
         cls.inv_file_name = os.path.join(os.path.dirname(__file__), 'data/ground_truth_inv.txt')
         cls.y_true_inv, cls.y_pred_inv = cls.load_labels(cls, cls.inv_file_name)
 
-    def test_get_entities(self):
+    def test_get_entities_with_criteria_exact(self):
         y_true = ['O', 'O', 'O', 'B-MISC', 'I-MISC', 'I-MISC', 'O', 'B-PER', 'I-PER']
         self.assertEqual(get_entities(y_true), [('MISC', 3, 5), ('PER', 7, 8)])
+    
+    def test_get_entities_with_criteria_left(self):
+        y_true = ['O', 'O', 'O', 'B-MISC', 'I-MISC', 'I-MISC', 'O', 'B-PER', 'I-PER']
+        self.assertEqual(get_entities(y_true, criteria='left'), [('MISC', 3), ('PER', 7)])
+    
+    def test_get_entities_with_criteria_right(self):
+        y_true = ['O', 'O', 'O', 'B-MISC', 'I-MISC', 'I-MISC', 'O', 'B-PER', 'I-PER']
+        self.assertEqual(get_entities(y_true, criteria='left'), [('MISC', 5), ('PER', 8)])
 
     def test_get_entities_with_suffix_style(self):
         y_true = ['O', 'O', 'O', 'MISC-B', 'MISC-I', 'MISC-I', 'O', 'PER-B', 'PER-I']
@@ -68,7 +76,7 @@ class TestMetrics(unittest.TestCase):
             self.assertLess(abs(f1_pred - f1_true), 1e-4)
 
     def test_metrics_for_inv_data(self):
-        with open(self.file_name) as f:
+        with open(self.file_name) as _:
             acc_pred = accuracy_score(self.y_true, self.y_pred)
             p_pred = precision_score(self.y_true, self.y_pred)
             r_pred = recall_score(self.y_true, self.y_pred)
@@ -183,7 +191,7 @@ class TestMetrics(unittest.TestCase):
         types = ['PER', 'MISC', 'ORG', 'LOC']
         report = ''
         raw_fmt = '{} {} {} {}\n'
-        for i in range(1000):
+        for _ in range(1000):
             type_true = random.choice(types)
             type_pred = random.choice(types)
             prefix_true = random.choice(prefixes)


### PR DESCRIPTION
# Overview 

This pull request adds the ability to use relaxed scoring criteria for `f1_score`, `precision_score`, `recall_score` and in `classification_report`. 

## Usage

The API is as follows:

```python
>>> from seqeval.metrics import f1_score
>>> y_true = [['O', 'O', 'O', 'B-MISC', 'I-MISC', 'I-MISC', 'O'], ['B-PER', 'I-PER', 'O']]
>>> y_pred = [['O', 'O', 'B-MISC', 'I-MISC', 'I-MISC', 'I-MISC', 'O'], ['B-PER', 'I-PER', 'O']]
>>> f1_score(y_true, y_pred, criteria='exact')
0.5
>>> f1_score(y_true, y_pred, criteria='left')
0.5
>>> f1_score(y_true, y_pred, criteria='right')
1.0
>>> f1_score(y_true, y_pred, criteria='invalid')
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-8-bbb92f06f8d2> in <module>
----> 1 f1_score(y_true, y_pred, criteria='invalid')

~/Downloads/seqeval/seqeval/metrics/sequence_labeling.py in f1_score(y_true, y_pred, average, criteria, suffix)
    160         err_msg = ("Expected criteria to be one of 'exact', 'left', or 'right'."
    161                    " Got: {}").format(criteria)
--> 162         raise ValueError(err_msg)
    163 
    164     true_entities = set(get_entities(y_true, criteria, suffix))

ValueError: Expected criteria to be one of 'exact', 'left', or 'right'. Got: invalid
```

The same keyword argument (`criteria`) can be provided to `precision_score`, `recall_score` and `classification_report`. The options for `criteria` are: `exact`, `right`, and `left` and (defaults to `exact`.)

```
>>> help(f1_score)

Help on function f1_score in module seqeval.metrics.sequence_labeling:

f1_score(y_true, y_pred, average='micro', criteria='exact', suffix=False)
    Compute the F1 score.
    
    The F1 score can be interpreted as a weighted average of the precision and
    recall, where an F1 score reaches its best value at 1 and worst score at 0.
    The relative contribution of precision and recall to the F1 score are
    equal. The formula for the F1 score is::
    
        F1 = 2 * (precision * recall) / (precision + recall)
    
    Args:
        y_true : 2d array. Ground truth (correct) target values.
        y_pred : 2d array. Estimated targets as returned by a tagger.
        criteria (str): Optional, criteria which will be used for evaluation.
            'exact' matches boundaries  directly, 'left' requires only a left
            boundary match and 'right' requires only a right boundary match.
            Defaults to 'exact'.
    
    Returns:
        score : float.
    
    Example:
        >>> from seqeval.metrics import f1_score
        >>> y_true = [['O', 'O', 'O', 'B-MISC', 'I-MISC', 'I-MISC', 'O'], ['B-PER', 'I-PER', 'O']]
        >>> y_pred = [['O', 'O', 'B-MISC', 'I-MISC', 'I-MISC', 'I-MISC', 'O'], ['B-PER', 'I-PER', 'O']]
        >>> f1_score(y_true, y_pred)
        0.50
```

## Use cases

Relaxed scoring criteria are useful when an exact match is less important than a right or left boundary match. For example, in biomedical NER, entities can be very long with many adjectives and modifiers, in which case we [might want to relax the scoring criteria to right-boundary matching](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1402329/). 

Or, as we have done [in our recent paper](https://academic.oup.com/bioinformatics/advance-article/doi/10.1093/bioinformatics/btz504/5520946), relaxed scoring might be used in cross-corpus evaluations.

## Todo's

- [ ] Add unit tests. _I added these for `get_entities`. Is one of the package maintainers able to add it for the `*_score` functions?_ 