### PR TITLE
🐛 [BugFix] Fix wrong FP calculation

### DIFF
--- a/seqeval/metrics/sequence_labeling.py
+++ b/seqeval/metrics/sequence_labeling.py
@@ -268,7 +268,7 @@ def performance_measure(y_true, y_pred):
         >>> y_true = [['O', 'O', 'O', 'B-MISC', 'I-MISC', 'O', 'B-ORG'], ['B-PER', 'I-PER', 'O']]
         >>> y_pred = [['O', 'O', 'B-MISC', 'I-MISC', 'I-MISC', 'O', 'O'], ['B-PER', 'I-PER', 'O']]
         >>> performance_measure(y_true, y_pred)
-        (3, 3, 1, 4)
+        {'TP': 3, 'FP': 2, 'FN': 1, 'TN': 4}
     """
     performace_dict = dict()
     if any(isinstance(s, list) for s in y_true):
@@ -276,7 +276,7 @@ def performance_measure(y_true, y_pred):
         y_pred = [item for sublist in y_pred for item in sublist]
     performace_dict['TP'] = sum(y_t == y_p for y_t, y_p in zip(y_true, y_pred)
                                 if ((y_t != 'O') or (y_p != 'O')))
-    performace_dict['FP'] = sum(y_t != y_p for y_t, y_p in zip(y_true, y_pred))
+    performace_dict['FP'] = sum(((y_t != 'O') != (y_p != 'O')) for y_t, y_p in zip(y_true, y_pred))
     performace_dict['FN'] = sum(((y_t != 'O') and (y_p == 'O'))
                                 for y_t, y_p in zip(y_true, y_pred))
     performace_dict['TN'] = sum((y_t == y_p == 'O')

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -44,7 +44,7 @@ class TestMetrics(unittest.TestCase):
         y_pred = [['O', 'O', 'B-MISC', 'I-MISC', 'I-MISC', 'O', 'O'], ['B-PER', 'I-PER', 'O']]
         performance_dict = performance_measure(y_true, y_pred)
         self.assertDictEqual(performance_dict, {
-                             'FN': 1, 'FP': 3, 'TN': 4, 'TP': 3})
+                             'FN': 1, 'FP': 2, 'TN': 4, 'TP': 3})
 
     def test_classification_report(self):
         print(classification_report(self.y_true, self.y_pred))


### PR DESCRIPTION
In test example:
`FP` should have been 2 but because of the wrong operator condition - it was including FN also. Total instances should sum up to `10` and previously it was wrong - `11`.

Fixed to consider only `B`,`I` tags and excluding `O` tags for FP calculation.