### PR TITLE
Add validation for an input

### DIFF
--- a/seqeval/metrics/sequence_labeling.py
+++ b/seqeval/metrics/sequence_labeling.py
@@ -27,6 +27,19 @@ def get_entities(seq, suffix=False):
         >>> get_entities(seq)
         [('PER', 0, 1), ('LOC', 3, 3)]
     """
+
+    def _validate_chunk(chunk, suffix):
+        if chunk == 'O':
+            return
+
+        if suffix:
+            if not (chunk.endswith('-B') or chunk.endswith('-I')):
+                raise ValueError('Invalid tag is found: {}'.format(chunk))
+
+        else:
+            if not (chunk.startswith('B-') or chunk.startswith('I-')):
+                raise ValueError('Invalid tag is found: {}'.format(chunk))
+
     # for nested list
     if any(isinstance(s, list) for s in seq):
         seq = [item for sublist in seq for item in sublist + ['O']]
@@ -36,6 +49,8 @@ def get_entities(seq, suffix=False):
     begin_offset = 0
     chunks = []
     for i, chunk in enumerate(seq + ['O']):
+        _validate_chunk(chunk, suffix)
+
         if suffix:
             tag = chunk[-1]
             type_ = chunk.split('-')[0]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -43,7 +43,11 @@ class TestMetrics(unittest.TestCase):
         y_true = ['O', 'O', 'O', 'MISC', 'MISC', 'MISC', 'O', 'PER', 'PER']
         with self.assertRaises(Exception):
             get_entities(y_true)
-            get_entities(y_true, suffix=True)
+
+    def test_get_entities_with_unexpected_input_and_suffix_style(self):
+        y_true = ['O', 'O', 'O', 'MISC', 'MISC', 'MISC', 'O', 'PER', 'PER']
+        with self.assertRaises(Exception):
+            get_entities(y_true)
 
     def test_performance_measure(self):
         y_true = [['O', 'O', 'O', 'B-MISC', 'I-MISC', 'O', 'B-ORG'], ['B-PER', 'I-PER', 'O']]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -39,6 +39,12 @@ class TestMetrics(unittest.TestCase):
         y_true = ['O', 'O', 'O', 'MISC-B', 'MISC-I', 'MISC-I', 'O', 'PER-B', 'PER-I']
         self.assertEqual(get_entities(y_true, suffix=True), [('MISC', 3, 5), ('PER', 7, 8)])
 
+    def test_get_entities_with_unexpected_input(self):
+        y_true = ['O', 'O', 'O', 'MISC', 'MISC', 'MISC', 'O', 'PER', 'PER']
+        with self.assertRaises(Exception):
+            get_entities(y_true)
+            get_entities(y_true, suffix=True)
+
     def test_performance_measure(self):
         y_true = [['O', 'O', 'O', 'B-MISC', 'I-MISC', 'O', 'B-ORG'], ['B-PER', 'I-PER', 'O']]
         y_pred = [['O', 'O', 'B-MISC', 'I-MISC', 'I-MISC', 'O', 'O'], ['B-PER', 'I-PER', 'O']]


### PR DESCRIPTION
This PR introduces a validation for each tag passed to `get_entities`.
The current implementation works without any error on an input that is not formatted for NER.
It would be better to raise an Exception for them.

```python
$ cat demo.py
from seqeval.metrics.sequence_labeling import get_entities


y_true = ['O', 'O', 'O', 'MISC', 'MISC', 'MISC', 'O', 'PER', 'PER']
print(get_entities(y_true))
print(get_entities(y_true, suffix=True))
```

### Before

```
$ poetry run python demo.py
[('MISC', 3, 5), ('PER', 7, 8)]
[('MISC', 3, 5), ('PER', 7, 8)]
```

### After (this PR)

```
$ poetry run python demo.py                                                                                                                                                                                                                             ± [ ● ][add-validation]
Traceback (most recent call last):
  File "demo.py", line 5, in <module>
    print(get_entities(y_true))
  File "/Users/makoto-hiramatsu/work/github.com/himkt/seqeval/seqeval/metrics/sequence_labeling.py", line 52, in get_entities
    _validate_chunk(chunk, suffix)
  File "/Users/makoto-hiramatsu/work/github.com/himkt/seqeval/seqeval/metrics/sequence_labeling.py", line 41, in _validate_chunk
    raise ValueError('Invalid tag is found: {}'.format(chunk))
ValueError: Invalid tag is found: MISC
```


cc. @fufufukakaka (who found this behavior)