### PR TITLE
Fix for classification report when tag contain dash in their names

### DIFF
--- a/seqeval/metrics/sequence_labeling.py
+++ b/seqeval/metrics/sequence_labeling.py
@@ -38,10 +38,10 @@ def get_entities(seq, suffix=False):
     for i, chunk in enumerate(seq + ['O']):
         if suffix:
             tag = chunk[-1]
-            type_ = chunk.split('-')[0]
+            type_ = '-'.join(chunk.split('-')[:-1])
         else:
             tag = chunk[0]
-            type_ = '-'.join(chunk.split('-')[:-1])
+            type_ = '-'.join(chunk.split('-')[1:])
 
         if end_of_chunk(prev_tag, tag, prev_type, type_):
             chunks.append((prev_type, begin_offset, i-1))

--- a/seqeval/metrics/sequence_labeling.py
+++ b/seqeval/metrics/sequence_labeling.py
@@ -41,7 +41,7 @@ def get_entities(seq, suffix=False):
             type_ = chunk.split('-')[0]
         else:
             tag = chunk[0]
-            type_ = chunk.split('-')[-1]
+            type_ = '-'.join(chunk.split('-')[:-1])
 
         if end_of_chunk(prev_tag, tag, prev_type, type_):
             chunks.append((prev_type, begin_offset, i-1))


### PR DESCRIPTION
Without this fix, if somebody named tags like: 'B-XX-YY' and 'B-ZZ-YY', their results seem to be put together into 'YY' in the classification report.