### PR TITLE
Stop raising exception when `get_entities` takes a non-NE input

### DIFF
--- a/seqeval/metrics/sequence_labeling.py
+++ b/seqeval/metrics/sequence_labeling.py
@@ -8,6 +8,7 @@ from __future__ import division
 from __future__ import print_function
 
 from collections import defaultdict
+import warnings
 
 import numpy as np
 
@@ -34,11 +35,11 @@ def get_entities(seq, suffix=False):
 
         if suffix:
             if not (chunk.endswith('-B') or chunk.endswith('-I') or chunk.endswith('-E') or chunk.endswith('-S')):
-                raise ValueError('Invalid tag is found: {}'.format(chunk))
+                warnings.warn('{} seems not to be NE tag.'.format(chunk))
 
         else:
             if not (chunk.startswith('B-') or chunk.startswith('I-') or chunk.startswith('E-') or chunk.startswith('S-')):
-                raise ValueError('Invalid tag is found: {}'.format(chunk))
+                warnings.warn('{} seems not to be NE tag.'.format(chunk))
 
     # for nested list
     if any(isinstance(s, list) for s in seq):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -43,11 +43,7 @@ class TestMetrics(unittest.TestCase):
         y_true = ['O', 'O', 'O', 'MISC', 'MISC', 'MISC', 'O', 'PER', 'PER']
         with self.assertRaises(Exception):
             get_entities(y_true)
-
-    def test_get_entities_with_unexpected_input_and_suffix_style(self):
-        y_true = ['O', 'O', 'O', 'MISC', 'MISC', 'MISC', 'O', 'PER', 'PER']
-        with self.assertRaises(Exception):
-            get_entities(y_true)
+            get_entities(y_true, suffix=True)
 
     def test_get_entities_with_only_IOB(self):
         y_true = [['O', 'O', 'O', 'B', 'I', 'I', 'O'], ['B', 'I', 'O']]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -39,10 +39,12 @@ class TestMetrics(unittest.TestCase):
         y_true = ['O', 'O', 'O', 'MISC-B', 'MISC-I', 'MISC-I', 'O', 'PER-B', 'PER-I']
         self.assertEqual(get_entities(y_true, suffix=True), [('MISC', 3, 5), ('PER', 7, 8)])
 
-    def test_get_entities_with_unexpected_input(self):
+    def test_get_entities_with_non_NE_input(self):
         y_true = ['O', 'O', 'O', 'MISC', 'MISC', 'MISC', 'O', 'PER', 'PER']
-        with self.assertRaises(Exception):
+        with self.assertWarns(UserWarning):
             get_entities(y_true)
+
+        with self.assertWarns(UserWarning):
             get_entities(y_true, suffix=True)
 
     def test_get_entities_with_only_IOB(self):


### PR DESCRIPTION
ref. https://github.com/chakki-works/seqeval/pull/30#issuecomment-703065434

If users want to evaluate performance on some token-level tasks with `seqeval`,
they get an error raised from a validation introduced in https://github.com/chakki-works/seqeval/pull/30.
(I didn't consider that non-NE input is passed to `get_entities`.)

Following the suggestion by @djstrong (thank you for the report and suggestion!), I update `get_entities` such that it warns when non-NE input is passed.