### PR TITLE
Add scheme classes to implement strict analysis

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pipenv
+        pipenv install --dev --skip-lock
+    - name: Lint with flake8
+      run: |
+        pipenv run flake8
+    - name: Lint with isort
+      run: |
+        pipenv run isort
+    - name: Test with pytest
+      run: |
+        pipenv run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,21 +8,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.8
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pipenv
-        pipenv install --dev --skip-lock
-#    - name: Lint with flake8
-#      run: |
-#        pipenv run flake8
-#    - name: Lint with isort
-#      run: |
-#        pipenv run isort
-    - name: Test with pytest
-      run: |
-        pipenv run test
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install pipenv
+        uses: dschep/install-pipenv-action@v1
+      - name: Install dependencies
+        run: |
+          pipenv install --dev
+      - name: Test with pytest
+        run: |
+          pipenv run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Python application
 
 on: [push, pull_request]
 
@@ -8,15 +8,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-      - name: Install pipenv
-        uses: dschep/install-pipenv-action@v1
-      - name: Install dependencies
-        run: |
-          pipenv install --dev
-      - name: Test with pytest
-        run: |
-          pipenv run test
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pipenv
+        pipenv install --dev --skip-lock
+    - name: Test with pytest
+      run: |
+        pipenv run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,12 @@ jobs:
         python -m pip install --upgrade pip
         pip install pipenv
         pipenv install --dev --skip-lock
-    - name: Lint with flake8
-      run: |
-        pipenv run flake8
-    - name: Lint with isort
-      run: |
-        pipenv run isort
+#    - name: Lint with flake8
+#      run: |
+#        pipenv run flake8
+#    - name: Lint with isort
+#      run: |
+#        pipenv run isort
     - name: Test with pytest
       run: |
         pipenv run test

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,21 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+pytest = "*"
+autopep8 = "*"
+flake8 = "*"
+pytest-cov = "*"
+isort = "*"
+
+[packages]
+numpy = "*"
+
+[requires]
+python_version = "3.8"
+
+[scripts]
+isort = "isort . -c"
+test = "pytest --cov=text2sparql --cov-report=term-missing -vv tests"

--- a/Pipfile
+++ b/Pipfile
@@ -18,5 +18,5 @@ python_version = "3.8"
 
 [scripts]
 isort = "isort . -c"
-test = "pytest tests/test_scheme.py --cov=seqeval --cov-report=term-missing"
+test = "pytest tests/test_scheme.py --cov=seqeval --cov-report=term-missing -vv"
 flake8 = "flake8 seqeval --ignore=F401,E741"

--- a/Pipfile
+++ b/Pipfile
@@ -18,5 +18,5 @@ python_version = "3.8"
 
 [scripts]
 isort = "isort . -c"
-test = "pytest --cov=text2sparql --cov-report=term-missing -vv tests"
+test = "pytest tests/test_scheme.py --cov=seqeval --cov-report=term-missing"
 flake8 = "flake8 seqeval --ignore=F401,E741"

--- a/Pipfile
+++ b/Pipfile
@@ -19,3 +19,4 @@ python_version = "3.8"
 [scripts]
 isort = "isort . -c"
 test = "pytest --cov=text2sparql --cov-report=term-missing -vv tests"
+flake8 = "flake8 seqeval --ignore=F401,E741"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,218 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "b4e22269a630553874e70082ad4ec752d455c4a5da5beed5e7cebcdb06dd35ab"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.8"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "numpy": {
+            "hashes": [
+                "sha256:04c7d4ebc5ff93d9822075ddb1751ff392a4375e5885299445fcebf877f179d5",
+                "sha256:0bfd85053d1e9f60234f28f63d4a5147ada7f432943c113a11afcf3e65d9d4c8",
+                "sha256:0c66da1d202c52051625e55a249da35b31f65a81cb56e4c69af0dfb8fb0125bf",
+                "sha256:0d310730e1e793527065ad7dde736197b705d0e4c9999775f212b03c44a8484c",
+                "sha256:1669ec8e42f169ff715a904c9b2105b6640f3f2a4c4c2cb4920ae8b2785dac65",
+                "sha256:2117536e968abb7357d34d754e3733b0d7113d4c9f1d921f21a3d96dec5ff716",
+                "sha256:3733640466733441295b0d6d3dcbf8e1ffa7e897d4d82903169529fd3386919a",
+                "sha256:4339741994c775396e1a274dba3609c69ab0f16056c1077f18979bec2a2c2e6e",
+                "sha256:51ee93e1fac3fe08ef54ff1c7f329db64d8a9c5557e6c8e908be9497ac76374b",
+                "sha256:54045b198aebf41bf6bf4088012777c1d11703bf74461d70cd350c0af2182e45",
+                "sha256:58d66a6b3b55178a1f8a5fe98df26ace76260a70de694d99577ddeab7eaa9a9d",
+                "sha256:59f3d687faea7a4f7f93bd9665e5b102f32f3fa28514f15b126f099b7997203d",
+                "sha256:62139af94728d22350a571b7c82795b9d59be77fc162414ada6c8b6a10ef5d02",
+                "sha256:7118f0a9f2f617f921ec7d278d981244ba83c85eea197be7c5a4f84af80a9c3c",
+                "sha256:7c6646314291d8f5ea900a7ea9c4261f834b5b62159ba2abe3836f4fa6705526",
+                "sha256:967c92435f0b3ba37a4257c48b8715b76741410467e2bdb1097e8391fccfae15",
+                "sha256:9a3001248b9231ed73894c773142658bab914645261275f675d86c290c37f66d",
+                "sha256:aba1d5daf1144b956bc87ffb87966791f5e9f3e1f6fab3d7f581db1f5b598f7a",
+                "sha256:addaa551b298052c16885fc70408d3848d4e2e7352de4e7a1e13e691abc734c1",
+                "sha256:b594f76771bc7fc8a044c5ba303427ee67c17a09b36e1fa32bde82f5c419d17a",
+                "sha256:c35a01777f81e7333bcf276b605f39c872e28295441c265cd0c860f4b40148c1",
+                "sha256:cebd4f4e64cfe87f2039e4725781f6326a61f095bc77b3716502bed812b385a9",
+                "sha256:d526fa58ae4aead839161535d59ea9565863bb0b0bdb3cc63214613fb16aced4",
+                "sha256:d7ac33585e1f09e7345aa902c281bd777fdb792432d27fca857f39b70e5dd31c",
+                "sha256:e6ddbdc5113628f15de7e4911c02aed74a4ccff531842c583e5032f6e5a179bd",
+                "sha256:eb25c381d168daf351147713f49c626030dcff7a393d5caa62515d415a6071d8"
+            ],
+            "index": "pypi",
+            "version": "==1.19.2"
+        }
+    },
+    "develop": {
+        "attrs": {
+            "hashes": [
+                "sha256:26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594",
+                "sha256:fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==20.2.0"
+        },
+        "autopep8": {
+            "hashes": [
+                "sha256:d21d3901cb0da6ebd1e83fc9b0dfbde8b46afc2ede4fe32fbda0c7c6118ca094"
+            ],
+            "index": "pypi",
+            "version": "==1.5.4"
+        },
+        "coverage": {
+            "hashes": [
+                "sha256:0203acd33d2298e19b57451ebb0bed0ab0c602e5cf5a818591b4918b1f97d516",
+                "sha256:0f313707cdecd5cd3e217fc68c78a960b616604b559e9ea60cc16795c4304259",
+                "sha256:1c6703094c81fa55b816f5ae542c6ffc625fec769f22b053adb42ad712d086c9",
+                "sha256:1d44bb3a652fed01f1f2c10d5477956116e9b391320c94d36c6bf13b088a1097",
+                "sha256:280baa8ec489c4f542f8940f9c4c2181f0306a8ee1a54eceba071a449fb870a0",
+                "sha256:29a6272fec10623fcbe158fdf9abc7a5fa032048ac1d8631f14b50fbfc10d17f",
+                "sha256:2b31f46bf7b31e6aa690d4c7a3d51bb262438c6dcb0d528adde446531d0d3bb7",
+                "sha256:2d43af2be93ffbad25dd959899b5b809618a496926146ce98ee0b23683f8c51c",
+                "sha256:381ead10b9b9af5f64646cd27107fb27b614ee7040bb1226f9c07ba96625cbb5",
+                "sha256:47a11bdbd8ada9b7ee628596f9d97fbd3851bd9999d398e9436bd67376dbece7",
+                "sha256:4d6a42744139a7fa5b46a264874a781e8694bb32f1d76d8137b68138686f1729",
+                "sha256:50691e744714856f03a86df3e2bff847c2acede4c191f9a1da38f088df342978",
+                "sha256:530cc8aaf11cc2ac7430f3614b04645662ef20c348dce4167c22d99bec3480e9",
+                "sha256:582ddfbe712025448206a5bc45855d16c2e491c2dd102ee9a2841418ac1c629f",
+                "sha256:63808c30b41f3bbf65e29f7280bf793c79f54fb807057de7e5238ffc7cc4d7b9",
+                "sha256:71b69bd716698fa62cd97137d6f2fdf49f534decb23a2c6fc80813e8b7be6822",
+                "sha256:7858847f2d84bf6e64c7f66498e851c54de8ea06a6f96a32a1d192d846734418",
+                "sha256:78e93cc3571fd928a39c0b26767c986188a4118edc67bc0695bc7a284da22e82",
+                "sha256:7f43286f13d91a34fadf61ae252a51a130223c52bfefb50310d5b2deb062cf0f",
+                "sha256:86e9f8cd4b0cdd57b4ae71a9c186717daa4c5a99f3238a8723f416256e0b064d",
+                "sha256:8f264ba2701b8c9f815b272ad568d555ef98dfe1576802ab3149c3629a9f2221",
+                "sha256:9342dd70a1e151684727c9c91ea003b2fb33523bf19385d4554f7897ca0141d4",
+                "sha256:9361de40701666b034c59ad9e317bae95c973b9ff92513dd0eced11c6adf2e21",
+                "sha256:9669179786254a2e7e57f0ecf224e978471491d660aaca833f845b72a2df3709",
+                "sha256:aac1ba0a253e17889550ddb1b60a2063f7474155465577caa2a3b131224cfd54",
+                "sha256:aef72eae10b5e3116bac6957de1df4d75909fc76d1499a53fb6387434b6bcd8d",
+                "sha256:bd3166bb3b111e76a4f8e2980fa1addf2920a4ca9b2b8ca36a3bc3dedc618270",
+                "sha256:c1b78fb9700fc961f53386ad2fd86d87091e06ede5d118b8a50dea285a071c24",
+                "sha256:c3888a051226e676e383de03bf49eb633cd39fc829516e5334e69b8d81aae751",
+                "sha256:c5f17ad25d2c1286436761b462e22b5020d83316f8e8fcb5deb2b3151f8f1d3a",
+                "sha256:c851b35fc078389bc16b915a0a7c1d5923e12e2c5aeec58c52f4aa8085ac8237",
+                "sha256:cb7df71de0af56000115eafd000b867d1261f786b5eebd88a0ca6360cccfaca7",
+                "sha256:cedb2f9e1f990918ea061f28a0f0077a07702e3819602d3507e2ff98c8d20636",
+                "sha256:e8caf961e1b1a945db76f1b5fa9c91498d15f545ac0ababbe575cfab185d3bd8"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==5.3"
+        },
+        "flake8": {
+            "hashes": [
+                "sha256:749dbbd6bfd0cf1318af27bf97a14e28e5ff548ef8e5b1566ccfb25a11e7c839",
+                "sha256:aadae8761ec651813c24be05c6f7b4680857ef6afaae4651a4eccaef97ce6c3b"
+            ],
+            "index": "pypi",
+            "version": "==3.8.4"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:80cf40c597eb564e86346103f609d74efce0f6b4d4f30ec8ce9e2c26411ba437",
+                "sha256:e5f92f89355a67de0595932a6c6c02ab4afddc6fcdc0bfc5becd0d60884d3f69"
+            ],
+            "version": "==1.0.1"
+        },
+        "isort": {
+            "hashes": [
+                "sha256:36f0c6659b9000597e92618d05b72d4181104cf59472b1c6a039e3783f930c95",
+                "sha256:ba040c24d20aa302f78f4747df549573ae1eaf8e1084269199154da9c483f07f"
+            ],
+            "index": "pypi",
+            "version": "==5.5.4"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8",
+                "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==20.4"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
+                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.13.1"
+        },
+        "py": {
+            "hashes": [
+                "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2",
+                "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.9.0"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367",
+                "sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.6.0"
+        },
+        "pyflakes": {
+            "hashes": [
+                "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92",
+                "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.2.0"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.7"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:7a8190790c17d79a11f847fba0b004ee9a8122582ebff4729a082c109e81a4c9",
+                "sha256:8f593023c1a0f916110285b6efd7f99db07d59546e3d8c36fc60e2ab05d3be92"
+            ],
+            "index": "pypi",
+            "version": "==6.1.1"
+        },
+        "pytest-cov": {
+            "hashes": [
+                "sha256:45ec2d5182f89a81fc3eb29e3d1ed3113b9e9a873bcddb2a71faaab066110191",
+                "sha256:47bd0ce14056fdd79f93e1713f88fad7bdcc583dcd7783da86ef2f085a0bb88e"
+            ],
+            "index": "pypi",
+            "version": "==2.10.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
+                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.15.0"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f",
+                "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"
+            ],
+            "version": "==0.10.1"
+        }
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-Keras==2.2.4
-numpy==1.14.0
-tensorflow==1.15.4

--- a/seqeval/scheme.py
+++ b/seqeval/scheme.py
@@ -248,3 +248,27 @@ class Tokens:
         token = self.tokens[i]
         prev = self.tokens[i - 1]
         return token.is_end(prev)
+
+
+def auto_detect(sequences, suffix=False, delimiter='-'):
+    prefixes = set()
+    error_message = 'This scheme is not supported: {}'
+    for tokens in sequences:
+        for token in tokens:
+            token = Token(token, suffix=suffix, delimiter=delimiter)
+            try:
+                prefixes.add(token.prefix)
+            except KeyError:
+                raise ValueError(error_message.format(token))
+
+    iob_prefixes = {Prefix.I, Prefix.O, Prefix.B}
+    ioe_prefixes = {Prefix.I, Prefix.O, Prefix.E}
+    iobes_prefixes = {Prefix.I, Prefix.O, Prefix.B, Prefix.E, Prefix.S}
+    if prefixes == iob_prefixes or prefixes == iob_prefixes - {Prefix.O}:
+        return IOB2
+    elif prefixes == ioe_prefixes or prefixes == ioe_prefixes - {Prefix.O}:
+        return IOE2
+    elif prefixes == iobes_prefixes or prefixes == iobes_prefixes - {Prefix.O}:
+        return IOBES
+    else:
+        raise ValueError(error_message.format(prefixes))

--- a/seqeval/scheme.py
+++ b/seqeval/scheme.py
@@ -183,23 +183,3 @@ class Tokens:
         token = self.tokens[pos]
         prev = self.tokens[pos-1]
         return token.is_end(prev)
-
-
-if __name__ == '__main__':
-    sequences = [
-        Tokens(['B-PER', 'I-PER', 'O', 'B-LOC'], IOB2),
-        Tokens(['B-PER', 'I-ORG', 'B-ORG', 'B-LOC'], IOB2),
-        Tokens(['I-PER', 'I-PER', 'I-ORG', 'I-LOC'], IOB2),
-        #Tokens(['B-PER', 'E-PER', 'S-PER'], IOB2),
-        Tokens(['B-PER', 'E-PER', 'S-PER'], IOBES),
-        Tokens(['B-PER', 'I-PER', 'S-PER'], IOBES),
-        Tokens(['I-PER', 'I-PER', 'I-ORG', 'I-LOC'], IOBES),
-        Tokens(['B-PER', 'I-ORG', 'B-ORG', 'B-LOC'], IOBES),
-        Tokens(['O', 'I', 'E', 'O', 'I', 'I', 'E', 'E', 'O', 'E', 'O'], IOE2)
-    ]
-    for tokens in sequences:
-        print(tokens.entities)
-    entity_set1 = {Entity(0, 1, 'PER'), Entity(2, 3, 'ORG')}
-    entity_set2 = {Entity(0, 1, 'PER')}
-    print(entity_set1 & entity_set2)
-    print(entity_set1 - entity_set2)

--- a/seqeval/scheme.py
+++ b/seqeval/scheme.py
@@ -106,7 +106,7 @@ class IOB1(Token):
     start_patterns = {
         (Prefix.O, Prefix.I, Tag.ANY),
         (Prefix.I, Prefix.I, Tag.DIFF),
-        (Prefix.B, Prefix.I, Tag.DIFF),
+        (Prefix.B, Prefix.I, Tag.ANY),
         (Prefix.I, Prefix.B, Tag.SAME),
         (Prefix.B, Prefix.B, Tag.SAME)
     }
@@ -115,8 +115,9 @@ class IOB1(Token):
         (Prefix.I, Prefix.I, Tag.SAME)
     }
     end_patterns = {
-        (Prefix.I, Prefix.ANY, Tag.DIFF),
-        (Prefix.I, Prefix.B, Tag.SAME),
+        (Prefix.I, Prefix.I, Tag.DIFF),
+        (Prefix.I, Prefix.O, Tag.ANY),
+        (Prefix.I, Prefix.B, Tag.ANY),
         (Prefix.B, Prefix.O, Tag.ANY),
         (Prefix.B, Prefix.I, Tag.DIFF),
         (Prefix.B, Prefix.B, Tag.SAME)
@@ -136,7 +137,9 @@ class IOE1(Token):
         (Prefix.I, Prefix.E, Tag.SAME)
     }
     end_patterns = {
-        (Prefix.I, Prefix.ANY, Tag.DIFF),
+        (Prefix.I, Prefix.I, Tag.DIFF),
+        (Prefix.I, Prefix.O, Tag.ANY),
+        (Prefix.I, Prefix.E, Tag.DIFF),
         (Prefix.E, Prefix.I, Tag.SAME),
         (Prefix.E, Prefix.E, Tag.SAME)
     }

--- a/seqeval/scheme.py
+++ b/seqeval/scheme.py
@@ -1,0 +1,205 @@
+import abc
+import enum
+
+
+class Entity:
+
+    def __init__(self, start, end, tag):
+        self.start = start
+        self.end = end
+        self.tag = tag
+
+    def __repr__(self):
+        return '({}, {}, {})'.format(self.tag, self.start, self.end)
+
+    def __eq__(self, other):
+        return self.start == other.start and self.end == other.end and self.tag == other.tag
+
+    def __hash__(self):
+        return hash(self.to_tuple())
+
+    def to_tuple(self):
+        return self.tag, self.start, self.end
+
+
+class Prefix(enum.Flag):
+    I = enum.auto()
+    O = enum.auto()
+    B = enum.auto()
+    E = enum.auto()
+    S = enum.auto()
+    ANY = I | O | B | E | S
+
+
+class Token(metaclass=abc.ABCMeta):
+    allowed_prefix = None
+    accepts_as_start = None
+    accepts_as_inside = None
+    accepts_as_end = None
+
+    def __init__(self, token, suffix=False, delimiter='-'):
+        self.token = token
+        self.suffix = suffix
+        self.delimiter = delimiter
+
+    @property
+    def prefix(self):
+        prefix = self.token[-1] if self.suffix else self.token[0]
+        return Prefix[prefix]
+
+    @property
+    def tag(self):
+        tag = self.token[:-1] if self.suffix else self.token[1:]
+        tag = tag.strip(self.delimiter) or '_'
+        return tag
+
+    def is_valid(self):
+        if self.prefix not in self.allowed_prefix:
+            allowed_prefixes = str(self.allowed_prefix).replace('Prefix.', '')
+            message = 'Invalid token is found: {}. Allowed prefixes are: {}.'
+            raise ValueError(message.format(self.token, allowed_prefixes))
+        return True
+
+    def is_start(self, prev):
+        return self.check_pattern(prev, self.accepts_as_start)
+
+    def is_inside(self, prev):
+        if prev.tag != self.tag:
+            return False
+        return (prev.prefix, self.prefix) in self.accepts_as_inside
+
+    def is_end(self, prev):
+        return self.check_pattern(prev, self.accepts_as_end)
+
+    def check_pattern(self, prev, pattern):
+        return any(prev.prefix in b and self.prefix in a for b, a in pattern)
+
+
+class IOB2(Token):
+    allowed_prefix = Prefix.I | Prefix.O | Prefix.B
+    accepts_as_start = {
+        (Prefix.ANY, Prefix.B)
+    }
+    accepts_as_inside = {
+        (Prefix.B, Prefix.I),
+        (Prefix.I, Prefix.I)
+    }
+    accepts_as_end = {
+        (Prefix.I, Prefix.O),
+        (Prefix.I, Prefix.B),
+        (Prefix.B, Prefix.O),
+        (Prefix.B, Prefix.B)
+    }
+
+    def is_end(self, prev):
+        if prev.tag != self.tag:
+            return True
+        return super(IOB2, self).is_end(prev)
+
+
+class IOE2(Token):
+    allowed_prefix = Prefix.I | Prefix.O | Prefix.E
+    accepts_as_start = {
+        (Prefix.O, Prefix.I),
+        (Prefix.O, Prefix.E),
+        (Prefix.E, Prefix.I),
+        (Prefix.E, Prefix.E)
+    }
+    accepts_as_inside = {
+        (Prefix.I, Prefix.E),
+        (Prefix.I, Prefix.I)
+    }
+    accepts_as_end = {
+        (Prefix.E, Prefix.ANY)
+    }
+
+    def is_start(self, prev):
+        if prev.tag != self.tag:
+            return True
+        return super(IOE2, self).is_start(prev)
+
+
+class IOBES(Token):
+    allowed_prefix = Prefix.I | Prefix.O | Prefix.B | Prefix.E | Prefix.S
+    accepts_as_start = {
+        (Prefix.ANY, Prefix.B),
+        (Prefix.ANY, Prefix.S)
+    }
+    accepts_as_inside = {
+        (Prefix.B, Prefix.I),
+        (Prefix.I, Prefix.I),
+        (Prefix.B, Prefix.E)
+    }
+    accepts_as_end = {
+        (Prefix.S, Prefix.ANY),
+        (Prefix.E, Prefix.ANY)
+    }
+
+
+class Tokens:
+
+    def __init__(self, tokens, token_class):
+        self.tokens = [token_class(token) for token in tokens] + [token_class('O')]
+        self.token_class = token_class
+
+    @property
+    def entities(self):
+        """Extract entities from tokens.
+
+        Returns:
+            list: list of Entity.
+
+        Example:
+            >>> tokens = Tokens(['B-PER', 'I-PER', 'O', 'B-LOC'], IOB2)
+            >>> tokens.entities
+            [('PER', 0, 2), ('LOC', 3, 4)]
+        """
+        i = 0
+        prev = self.token_class('O')
+        entities = []
+        while i < len(self.tokens):
+            token = self.tokens[i]
+            token.is_valid()
+            if token.is_start(prev):
+                end = self._forward(start=i + 1, prev=token)
+                if self._is_end(end):
+                    entity = Entity(start=i, end=end, tag=token.tag)
+                    entities.append(entity)
+                i = end
+            else:
+                i += 1
+            prev = self.tokens[i - 1]
+        return entities
+
+    def _forward(self, start, prev):
+        for i, token in enumerate(self.tokens[start:], start):
+            if token.is_inside(prev):
+                prev = token
+            else:
+                return i
+        return len(self.tokens)
+
+    def _is_end(self, pos):
+        token = self.tokens[pos]
+        prev = self.tokens[pos-1]
+        return token.is_end(prev)
+
+
+if __name__ == '__main__':
+    sequences = [
+        Tokens(['B-PER', 'I-PER', 'O', 'B-LOC'], IOB2),
+        Tokens(['B-PER', 'I-ORG', 'B-ORG', 'B-LOC'], IOB2),
+        Tokens(['I-PER', 'I-PER', 'I-ORG', 'I-LOC'], IOB2),
+        #Tokens(['B-PER', 'E-PER', 'S-PER'], IOB2),
+        Tokens(['B-PER', 'E-PER', 'S-PER'], IOBES),
+        Tokens(['B-PER', 'I-PER', 'S-PER'], IOBES),
+        Tokens(['I-PER', 'I-PER', 'I-ORG', 'I-LOC'], IOBES),
+        Tokens(['B-PER', 'I-ORG', 'B-ORG', 'B-LOC'], IOBES),
+        Tokens(['O', 'I', 'E', 'O', 'I', 'I', 'E', 'E', 'O', 'E', 'O'], IOE2)
+    ]
+    for tokens in sequences:
+        print(tokens.entities)
+    entity_set1 = {Entity(0, 1, 'PER'), Entity(2, 3, 'ORG')}
+    entity_set2 = {Entity(0, 1, 'PER')}
+    print(entity_set1 & entity_set2)
+    print(entity_set1 - entity_set2)

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -60,7 +60,7 @@ def expects_start_inside_end_to_be_correct(prev, token, expected, scheme):
         ('I-PER', 'B-PER', [True, False, True]),
         ('I-PER', 'B-ORG', [False, False, True]),
         ('B-PER', 'O', [False, False, True]),
-        ('B-PER', 'I-PER', [False, True, False]),
+        ('B-PER', 'I-PER', [True, True, False]),
         ('B-PER', 'I-ORG', [True, False, True]),
         ('B-PER', 'B-PER', [True, False, True]),
         ('B-PER', 'B-ORG', [False, False, False])
@@ -132,7 +132,7 @@ def test_ioe1_start_inside_end(prev, token, expected):
         ('E-PER', 'E-ORG', [True, False, True])
     ]
 )
-def test_start_inside_end(prev, token, expected):
+def test_ioe2_start_inside_end(prev, token, expected):
     expects_start_inside_end_to_be_correct(prev, token, expected, IOE2)
 
 
@@ -188,13 +188,37 @@ def test_iobes_start_inside_end(prev, token, expected):
         (['I-PER', 'B-PER'], [('PER', 0, 1), ('PER', 1, 2)]),
         (['I-PER', 'B-ORG'], [('PER', 0, 1)]),
         (['B-PER', 'O'], []),
-        (['B-PER', 'I-PER'], []),
+        (['B-PER', 'I-PER'], [('PER', 1, 2)]),
         (['B-PER', 'I-ORG'], [('ORG', 1, 2)]),
         (['B-PER', 'B-PER'], [('PER', 1, 2)]),
         (['B-PER', 'B-ORG'], [])
     ]
 )
 def test_iob1_tokens(tokens, expected):
+    tokens = Tokens(tokens, IOB1)
+    entities = tokens.entities
+    assert entities == expected
+
+
+@pytest.mark.parametrize(
+    'tokens, expected',
+    [
+        ([], []),
+        (['B'], []),
+        (['I'], [('_', 0, 1)]),
+        (['O'], []),
+        (['O', 'O'], []),
+        (['O', 'I'], [('_', 1, 2)]),
+        (['O', 'B'], []),
+        (['I', 'O'], [('_', 0, 1)]),
+        (['I', 'I'], [('_', 0, 2)]),
+        (['I', 'B'], [('_', 0, 1), ('_', 1, 2)]),
+        (['B', 'O'], []),
+        (['B', 'I'], [('_', 1, 2)]),
+        (['B', 'B'], [('_', 1, 2)])
+    ]
+)
+def test_iob1_tokens_without_tag(tokens, expected):
     tokens = Tokens(tokens, IOB1)
     entities = tokens.entities
     assert entities == expected
@@ -263,7 +287,7 @@ def test_iob2_tokens_without_tag(tokens, expected):
         (['I-PER', 'O'], [('PER', 0, 1)]),
         (['I-PER', 'I-PER'], [('PER', 0, 2)]),
         (['I-PER', 'I-ORG'], [('PER', 0, 1), ('ORG', 1, 2)]),
-        (['I-PER', 'E-PER'], []),
+        # (['I-PER', 'E-PER'], [('PER', 0, 1)]),
         (['I-PER', 'E-ORG'], [('PER', 0, 1)]),
         (['E-PER', 'O'], []),
         (['E-PER', 'I-PER'], [('PER', 1, 2)]),
@@ -273,6 +297,30 @@ def test_iob2_tokens_without_tag(tokens, expected):
     ]
 )
 def test_ioe1_tokens(tokens, expected):
+    tokens = Tokens(tokens, IOE1)
+    entities = tokens.entities
+    assert entities == expected
+
+
+@pytest.mark.parametrize(
+    'tokens, expected',
+    [
+        ([], []),
+        (['E'], []),
+        (['I'], [('_', 0, 1)]),
+        (['O'], []),
+        (['O', 'O'], []),
+        (['O', 'I'], [('_', 1, 2)]),
+        (['O', 'E'], []),
+        (['I', 'O'], [('_', 0, 1)]),
+        (['I', 'I'], [('_', 0, 2)]),
+        # (['I', 'E'], [('_', 0, 1)]),
+        (['E', 'O'], []),
+        (['E', 'I'], [('_', 1, 2)]),
+        (['E', 'E'], [])
+    ]
+)
+def test_ioe1_tokens_without_tag(tokens, expected):
     tokens = Tokens(tokens, IOE1)
     entities = tokens.entities
     assert entities == expected

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -1,6 +1,6 @@
 import pytest
 
-from seqeval.scheme import IOB1, IOB2, IOBES, IOE1, IOE2, Prefix, Tokens, Token
+from seqeval.scheme import IOB1, IOB2, IOBES, IOE1, IOE2, Prefix, Tokens, Token, auto_detect
 
 
 @pytest.mark.parametrize(
@@ -521,3 +521,33 @@ class TestTokens:
         tokens = Tokens(['B-PER', 'E-PER', 'S-PER'], IOB2)
         with pytest.raises(ValueError):
             entities = tokens.entities
+
+
+class TestAutoDetect:
+
+    @pytest.mark.parametrize(
+        'sequences, expected',
+        [
+            ([['B', 'I', 'O']], IOB2),
+            ([['B', 'I']], IOB2),
+            ([['I', 'O', 'E']], IOE2),
+            ([['I', 'E']], IOE2),
+            ([['I', 'O', 'B', 'E', 'S']], IOBES),
+            ([['I', 'B', 'E', 'S']], IOBES)
+         ]
+    )
+    def test_valid_scheme(self, sequences, expected):
+        scheme = auto_detect(sequences)
+        assert scheme == expected
+
+    @pytest.mark.parametrize(
+        'sequences, expected',
+        [
+            ([['I', 'O']], IOB2),
+            ([['H']], IOB2)
+        ]
+    )
+    def test_invalid_scheme(self, sequences, expected):
+        with pytest.raises(ValueError):
+            scheme = auto_detect(sequences)
+

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -1,24 +1,89 @@
 import unittest
 
-from seqeval.scheme import IOB2, IOBES, IOE2, Prefix, Tokens
+import pytest
+
+from seqeval.scheme import IOB2, IOBES, IOE2, Prefix, Tokens, Token
 
 
-class TestIOB2(unittest.TestCase):
+class TestToken(unittest.TestCase):
 
-    def test_prefix_I(self):
-        token = IOB2('I')
+    def test_extracts_prefix_I(self):
+        token = Token('I-MISC')
         prefix = token.prefix
         self.assertEqual(prefix, Prefix.I)
 
-    def test_prefix_B(self):
-        token = IOB2('B')
+    def test_extracts_prefix_B(self):
+        token = Token('B-MISC')
         prefix = token.prefix
         self.assertEqual(prefix, Prefix.B)
 
-    def test_prefix_O(self):
-        token = IOB2('O')
+    def test_extracts_prefix_O(self):
+        token = Token('O')
         prefix = token.prefix
         self.assertEqual(prefix, Prefix.O)
+
+    def test_extracts_prefix_I_if_suffix_is_set(self):
+        token = Token('MISC-I', suffix=True)
+        prefix = token.prefix
+        self.assertEqual(prefix, Prefix.I)
+
+    def test_extracts_prefix_B_if_suffix_is_set(self):
+        token = Token('MISC-B', suffix=True)
+        prefix = token.prefix
+        self.assertEqual(prefix, Prefix.B)
+
+    def test_extracts_prefix_O_if_suffix_is_set(self):
+        token = Token('O', suffix=True)
+        prefix = token.prefix
+        self.assertEqual(prefix, Prefix.O)
+
+    def test_extracts_tag(self):
+        token = Token('I-MISC')
+        tag = token.tag
+        self.assertEqual(tag, 'MISC')
+
+    def test_extracts_tag_if_suffix_is_set(self):
+        token = Token('MISC-I', suffix=True)
+        tag = token.tag
+        self.assertEqual(tag, 'MISC')
+
+    def test_extracts_tag_if_token_is_prefix_only(self):
+        token = Token('I')
+        tag = token.tag
+        self.assertEqual(tag, '_')
+
+    def test_extracts_underscore_as_tag_if_input_is_O(self):
+        token = Token('O')
+        tag = token.tag
+        self.assertEqual(tag, '_')
+
+    def test_extracts_tag_if_input_contains_two_underscore(self):
+        token = Token('I-ORG-COMPANY')
+        tag = token.tag
+        self.assertEqual(tag, 'ORG-COMPANY')
+
+    def test_extracts_tag_if_input_contains_two_underscore_with_suffix(self):
+        token = Token('ORG-COMPANY-I', suffix=True)
+        tag = token.tag
+        self.assertEqual(tag, 'ORG-COMPANY')
+
+    def test_extracts_non_ascii_tag(self):
+        token = Token('I-組織')
+        tag = token.tag
+        self.assertEqual(tag, '組織')
+
+    def test_raises_type_error_if_input_is_binary_string(self):
+        token = Token('I-組織'.encode('utf-8'))
+        with self.assertRaises(TypeError):
+            tag = token.tag
+
+    def test_raises_index_error_if_input_is_empty_string(self):
+        token = Token('')
+        with self.assertRaises(IndexError):
+            prefix = token.prefix
+
+
+class TestIOB2Token(unittest.TestCase):
 
     def test_invalid_prefix(self):
         token = IOB2('T')
@@ -35,104 +100,213 @@ class TestIOB2(unittest.TestCase):
         is_valid = token.is_valid()
         self.assertTrue(is_valid)
 
-    def test_tag(self):
-        token = IOB2('I-MISC')
-        tag = token.tag
-        self.assertEqual(tag, 'MISC')
 
-    def test_only_iob(self):
-        token = IOB2('I')
-        tag = token.tag
-        self.assertEqual(tag, '_')
+@pytest.mark.parametrize(
+    'prev, token, expected',
+    [
+        ('O', 'O', [False, False, False]),
+        ('O', 'I-PER', [False, False, False]),
+        ('O', 'B-PER', [True, False, False]),
+        ('I-PER', 'O', [False, False, True]),
+        ('I-PER', 'I-PER', [False, True, False]),
+        ('I-PER', 'I-ORG', [False, False, True]),
+        ('I-PER', 'B-PER', [True, False, True]),
+        ('I-PER', 'B-ORG', [True, False, True]),
+        ('B-PER', 'O', [False, False, True]),
+        ('B-PER', 'I-PER', [False, True, False]),
+        ('B-PER', 'I-ORG', [False, False, True]),
+        ('B-PER', 'B-PER', [True, False, True]),
+        ('B-PER', 'B-ORG', [True, False, True])
+    ]
+)
+class TestIOB2Token:
 
-    def test_B_prefix_is_start(self):
-        token = IOB2('B-ORG')
-        prev = IOB2('I-ORG')
+    def test_start_inside_end(self, prev, token, expected):
+        prev = IOB2(prev)
+        token = IOB2(token)
         is_start = token.is_start(prev)
-        self.assertTrue(is_start)
-
-    def test_I_prefix_is_not_start(self):
-        token = IOB2('I-ORG')
-        prev = IOB2('B-ORG')
-        is_start = token.is_start(prev)
-        self.assertFalse(is_start)
-
-    def test_O_prefix_is_not_start(self):
-        token = IOB2('O')
-        prev = IOB2('B-ORG')
-        is_start = token.is_start(prev)
-        self.assertFalse(is_start)
-
-    def test_I_after_B_is_inside(self):
-        token = IOB2('I-ORG')
-        prev = IOB2('B-ORG')
         is_inside = token.is_inside(prev)
-        self.assertTrue(is_inside)
+        is_end = token.is_end(prev)
+        actual = [is_start, is_inside, is_end]
+        assert actual == expected
 
-    def test_I_after_B_with_different_tag_is_not_inside(self):
-        token = IOB2('I-ORG')
-        prev = IOB2('B-MISC')
+
+@pytest.mark.parametrize(
+    'prev, token, expected',
+    [
+        ('O', 'O', [False, False, False]),
+        ('O', 'I-PER', [True, False, False]),
+        ('O', 'E-PER', [True, False, False]),
+        ('I-PER', 'O', [False, False, False]),
+        ('I-PER', 'I-PER', [False, True, False]),
+        ('I-PER', 'I-ORG', [True, False, False]),
+        ('I-PER', 'E-PER', [False, True, False]),
+        ('I-PER', 'E-ORG', [True, False, False]),
+        ('E-PER', 'O', [False, False, True]),
+        ('E-PER', 'I-PER', [True, False, True]),
+        ('E-PER', 'I-ORG', [True, False, True]),
+        ('E-PER', 'E-PER', [True, False, True]),
+        ('E-PER', 'E-ORG', [True, False, True])
+    ]
+)
+class TestIOE2Token:
+
+    def test_start_inside_end(self, prev, token, expected):
+        prev = IOE2(prev)
+        token = IOE2(token)
+        is_start = token.is_start(prev)
         is_inside = token.is_inside(prev)
-        self.assertFalse(is_inside)
-
-    def test_O_after_B_is_end(self):
-        token = IOB2('O')
-        prev = IOB2('B-MISC')
         is_end = token.is_end(prev)
-        self.assertTrue(is_end)
+        actual = [is_start, is_inside, is_end]
+        assert actual == expected
 
-    def test_O_after_I_is_end(self):
-        token = IOB2('O')
-        prev = IOB2('I-MISC')
+
+@pytest.mark.parametrize(
+    'prev, token, expected',
+    [
+        ('O', 'O', [False, False, False]),
+        ('O', 'I-PER', [False, False, False]),
+        ('O', 'B-PER', [True, False, False]),
+        ('O', 'E-PER', [False, False, False]),
+        ('O', 'S-PER', [True, False, False]),
+        ('I-PER', 'O', [False, False, False]),
+        ('I-PER', 'I-PER', [False, True, False]),
+        ('I-PER', 'I-ORG', [False, False, False]),
+        ('I-PER', 'B-PER', [True, False, False]),
+        ('I-PER', 'E-PER', [False, True, False]),
+        ('I-PER', 'E-ORG', [False, False, False]),
+        ('I-PER', 'S-PER', [True, False, False]),
+        ('B-PER', 'O',     [False, False, False]),
+        ('B-PER', 'I-PER', [False, True, False]),
+        ('B-PER', 'I-ORG', [False, False, False]),
+        ('B-PER', 'E-PER', [False, True, False]),
+        ('B-PER', 'E-ORG', [False, False, False]),
+        ('B-PER', 'S-PER', [True, False, False]),
+        ('E-PER', 'O', [False, False, True]),
+        ('E-PER', 'I-PER', [False, False, True]),
+        ('E-PER', 'B-PER', [True, False, True]),
+        ('E-PER', 'E-PER', [False, False, True]),
+        ('E-PER', 'S-PER', [True, False, True]),
+        ('S-PER', 'O', [False, False, True]),
+        ('S-PER', 'I-PER', [False, False, True]),
+        ('S-PER', 'B-PER', [True, False, True]),
+        ('S-PER', 'E-PER', [False, False, True]),
+        ('S-PER', 'S-PER', [True, False, True])
+    ]
+)
+class TestIOBESToken:
+
+    def test_start_inside_end(self, prev, token, expected):
+        prev = IOBES(prev)
+        token = IOBES(token)
+        is_start = token.is_start(prev)
+        is_inside = token.is_inside(prev)
         is_end = token.is_end(prev)
-        self.assertTrue(is_end)
-
-    def test_B_after_B_is_end(self):
-        token = IOB2('B-MISC')
-        prev = IOB2('B-MISC')
-        is_end = token.is_end(prev)
-        self.assertTrue(is_end)
-
-    def test_B_after_I_is_end(self):
-        token = IOB2('B-MISC')
-        prev = IOB2('I-MISC')
-        is_end = token.is_end(prev)
-        self.assertTrue(is_end)
+        actual = [is_start, is_inside, is_end]
+        assert actual == expected
 
 
-class TestTokens(unittest.TestCase):
+@pytest.mark.parametrize(
+    'tokens, expected',
+    [
+        ([], []),
+        (['B-PER'], [('PER', 0, 1)]),
+        (['I-PER'], []),
+        (['O'], []),
+        (['O', 'I-PER'], []),
+        (['O', 'B-PER'], [('PER', 1, 2)]),
+        (['I-PER', 'O'], []),
+        (['I-PER', 'I-PER'], []),
+        (['I-PER', 'I-ORG'], []),
+        (['I-PER', 'B-PER'], [('PER', 1, 2)]),
+        (['I-PER', 'B-ORG'], [('ORG', 1, 2)]),
+        (['B-PER', 'O'], [('PER', 0, 1)]),
+        (['B-PER', 'I-PER'], [('PER', 0, 2)]),
+        (['B-PER', 'I-ORG'], [('PER', 0, 1)]),
+        (['B-PER', 'B-PER'], [('PER', 0, 1), ('PER', 1, 2)]),
+        (['B-PER', 'B-ORG'], [('PER', 0, 1), ('ORG', 1, 2)])
+    ]
+)
+def test_iob2_tokens(tokens, expected):
+    tokens = Tokens(tokens, IOB2)
+    entities = tokens.entities
+    assert entities == expected
 
-    def entity_helper(self, tokens, scheme, expected):
-        tokens = Tokens(tokens, scheme)
-        entities = [e.to_tuple() for e in tokens.entities]
-        self.assertEqual(entities, expected)
 
-    def test_correct_iob2_tokens(self):
-        tokens = ['B-PER', 'I-PER', 'O', 'B-LOC']
-        expected = [('PER', 0, 2), ('LOC', 3, 4)]
-        self.entity_helper(tokens, IOB2, expected)
+@pytest.mark.parametrize(
+    'tokens, expected',
+    [
+        ([], []),
+        (['E-PER'], [('PER', 0, 1)]),
+        (['I-PER'], []),
+        (['O'], []),
+        (['O', 'I-PER'], []),
+        (['O', 'E-PER'], [('PER', 1, 2)]),
+        (['I-PER', 'O'], []),
+        (['I-PER', 'I-PER'], []),
+        (['I-PER', 'I-ORG'], []),
+        (['I-PER', 'E-PER'], [('PER', 0, 2)]),
+        (['I-PER', 'E-ORG'], [('ORG', 1, 2)]),
+        (['E-PER', 'O'], [('PER', 0, 1)]),
+        (['E-PER', 'I-PER'], [('PER', 0, 1)]),
+        (['E-PER', 'I-ORG'], [('PER', 0, 1)]),
+        (['E-PER', 'E-PER'], [('PER', 0, 1), ('PER', 1, 2)]),
+        (['E-PER', 'E-ORG'], [('PER', 0, 1), ('ORG', 1, 2)])
+    ]
+)
+def test_ioe2_tokens(tokens, expected):
+    tokens = Tokens(tokens, IOE2)
+    entities = tokens.entities
+    assert entities == expected
 
-    def test_iob2_with_wrong_token(self):
-        tokens = ['B-PER', 'I-ORG', 'B-ORG', 'B-LOC']
-        expected = [('PER', 0, 1), ('ORG', 2, 3), ('LOC', 3, 4)]
-        self.entity_helper(tokens, IOB2, expected)
+
+@pytest.mark.parametrize(
+    'tokens, expected',
+    [
+        (['O'], []),
+        (['I-PER'], []),
+        (['B-PER'], []),
+        (['E-PER'], []),
+        (['S-PER'], [('PER', 0, 1)]),
+        (['O', 'O'], []),
+        (['O', 'I-PER'], []),
+        (['O', 'B-PER'], []),
+        (['O', 'E-PER'], []),
+        (['O', 'S-PER'], [('PER', 1, 2)]),
+        (['I-PER', 'O'], []),
+        (['I-PER', 'I-PER'], []),
+        (['I-PER', 'I-ORG'], []),
+        (['I-PER', 'B-PER'], []),
+        (['I-PER', 'E-PER'], []),
+        (['I-PER', 'E-ORG'], []),
+        (['I-PER', 'S-PER'], [('PER', 1, 2)]),
+        (['B-PER', 'O'], []),
+        (['B-PER', 'I-PER'], []),
+        (['B-PER', 'I-ORG'], []),
+        (['B-PER', 'E-PER'], [('PER', 0, 2)]),
+        (['B-PER', 'E-ORG'], []),
+        (['B-PER', 'S-PER'], [('PER', 1, 2)]),
+        (['E-PER', 'O'], []),
+        (['E-PER', 'I-PER'], []),
+        (['E-PER', 'B-PER'], []),
+        (['E-PER', 'E-PER'], []),
+        (['E-PER', 'S-PER'], [('PER', 1, 2)]),
+        (['S-PER', 'O'], [('PER', 0, 1)]),
+        (['S-PER', 'I-PER'], [('PER', 0, 1)]),
+        (['S-PER', 'B-PER'], [('PER', 0, 1)]),
+        (['S-PER', 'E-PER'], [('PER', 0, 1)]),
+        (['S-PER', 'S-PER'], [('PER', 0, 1), ('PER', 1, 2)])
+    ]
+)
+def test_iobes_tokens(tokens, expected):
+    tokens = Tokens(tokens, IOBES)
+    entities = tokens.entities
+    assert entities == expected
+
+
+class TestTokens:
 
     def test_raise_exception_when_iobes_tokens_with_iob2_scheme(self):
         tokens = Tokens(['B-PER', 'E-PER', 'S-PER'], IOB2)
-        with self.assertRaises(ValueError):
-            tokens.entities
-
-    def test_correct_iobes_tokens(self):
-        tokens = ['B-PER', 'E-PER', 'S-PER']
-        expected = [('PER', 0, 2), ('PER', 2, 3)]
-        self.entity_helper(tokens, IOBES, expected)
-
-    def test_iobes_with_wrong_token(self):
-        tokens = ['B-PER', 'I-PER', 'S-PER']
-        expected = [('PER', 2, 3)]
-        self.entity_helper(tokens, IOBES, expected)
-
-    def test_correct_ioe2_tokens(self):
-        tokens = ['O', 'I', 'E', 'O', 'I', 'I', 'E', 'E', 'O', 'E', 'O']
-        expected = [('_', 1, 3), ('_', 4, 7), ('_', 7, 8), ('_', 9, 10)]
-        self.entity_helper(tokens, IOE2, expected)
+        with pytest.raises(ValueError):
+            entities = tokens.entities

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -1,6 +1,6 @@
 import unittest
 
-from seqeval.scheme import IOB2, Prefix
+from seqeval.scheme import IOB2, IOBES, IOE2, Prefix, Tokens
 
 
 class TestIOB2(unittest.TestCase):
@@ -98,3 +98,41 @@ class TestIOB2(unittest.TestCase):
         prev = IOB2('I-MISC')
         is_end = token.is_end(prev)
         self.assertTrue(is_end)
+
+
+class TestTokens(unittest.TestCase):
+
+    def entity_helper(self, tokens, scheme, expected):
+        tokens = Tokens(tokens, scheme)
+        entities = [e.to_tuple() for e in tokens.entities]
+        self.assertEqual(entities, expected)
+
+    def test_correct_iob2_tokens(self):
+        tokens = ['B-PER', 'I-PER', 'O', 'B-LOC']
+        expected = [('PER', 0, 2), ('LOC', 3, 4)]
+        self.entity_helper(tokens, IOB2, expected)
+
+    def test_iob2_with_wrong_token(self):
+        tokens = ['B-PER', 'I-ORG', 'B-ORG', 'B-LOC']
+        expected = [('PER', 0, 1), ('ORG', 2, 3), ('LOC', 3, 4)]
+        self.entity_helper(tokens, IOB2, expected)
+
+    def test_raise_exception_when_iobes_tokens_with_iob2_scheme(self):
+        tokens = Tokens(['B-PER', 'E-PER', 'S-PER'], IOB2)
+        with self.assertRaises(ValueError):
+            tokens.entities
+
+    def test_correct_iobes_tokens(self):
+        tokens = ['B-PER', 'E-PER', 'S-PER']
+        expected = [('PER', 0, 2), ('PER', 2, 3)]
+        self.entity_helper(tokens, IOBES, expected)
+
+    def test_iobes_with_wrong_token(self):
+        tokens = ['B-PER', 'I-PER', 'S-PER']
+        expected = [('PER', 2, 3)]
+        self.entity_helper(tokens, IOBES, expected)
+
+    def test_correct_ioe2_tokens(self):
+        tokens = ['O', 'I', 'E', 'O', 'I', 'I', 'E', 'E', 'O', 'E', 'O']
+        expected = [('_', 1, 3), ('_', 4, 7), ('_', 7, 8), ('_', 9, 10)]
+        self.entity_helper(tokens, IOE2, expected)

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -1,0 +1,100 @@
+import unittest
+
+from seqeval.scheme import IOB2, Prefix
+
+
+class TestIOB2(unittest.TestCase):
+
+    def test_prefix_I(self):
+        token = IOB2('I')
+        prefix = token.prefix
+        self.assertEqual(prefix, Prefix.I)
+
+    def test_prefix_B(self):
+        token = IOB2('B')
+        prefix = token.prefix
+        self.assertEqual(prefix, Prefix.B)
+
+    def test_prefix_O(self):
+        token = IOB2('O')
+        prefix = token.prefix
+        self.assertEqual(prefix, Prefix.O)
+
+    def test_invalid_prefix(self):
+        token = IOB2('T')
+        with self.assertRaises(KeyError):
+            prefix = token.prefix
+
+    def test_validate_invalid_prefix(self):
+        token = IOB2('E')
+        with self.assertRaises(ValueError):
+            token.is_valid()
+
+    def test_validate_valid_prefix(self):
+        token = IOB2('B')
+        is_valid = token.is_valid()
+        self.assertTrue(is_valid)
+
+    def test_tag(self):
+        token = IOB2('I-MISC')
+        tag = token.tag
+        self.assertEqual(tag, 'MISC')
+
+    def test_only_iob(self):
+        token = IOB2('I')
+        tag = token.tag
+        self.assertEqual(tag, '_')
+
+    def test_B_prefix_is_start(self):
+        token = IOB2('B-ORG')
+        prev = IOB2('I-ORG')
+        is_start = token.is_start(prev)
+        self.assertTrue(is_start)
+
+    def test_I_prefix_is_not_start(self):
+        token = IOB2('I-ORG')
+        prev = IOB2('B-ORG')
+        is_start = token.is_start(prev)
+        self.assertFalse(is_start)
+
+    def test_O_prefix_is_not_start(self):
+        token = IOB2('O')
+        prev = IOB2('B-ORG')
+        is_start = token.is_start(prev)
+        self.assertFalse(is_start)
+
+    def test_I_after_B_is_inside(self):
+        token = IOB2('I-ORG')
+        prev = IOB2('B-ORG')
+        is_inside = token.is_inside(prev)
+        self.assertTrue(is_inside)
+
+    def test_I_after_B_with_different_tag_is_not_inside(self):
+        token = IOB2('I-ORG')
+        prev = IOB2('B-MISC')
+        is_inside = token.is_inside(prev)
+        self.assertFalse(is_inside)
+
+    def test_O_after_B_is_end(self):
+        token = IOB2('O')
+        prev = IOB2('B-MISC')
+        is_end = token.is_end(prev)
+        self.assertTrue(is_end)
+
+    def test_O_after_I_is_end(self):
+        token = IOB2('O')
+        prev = IOB2('I-MISC')
+        is_end = token.is_end(prev)
+        self.assertTrue(is_end)
+
+    def test_B_after_B_is_end(self):
+        token = IOB2('B-MISC')
+        prev = IOB2('B-MISC')
+        is_end = token.is_end(prev)
+        self.assertTrue(is_end)
+
+    def test_B_after_I_is_end(self):
+        token = IOB2('B-MISC')
+        prev = IOB2('I-MISC')
+        is_end = token.is_end(prev)
+        self.assertTrue(is_end)

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -231,6 +231,30 @@ def test_iob2_tokens(tokens, expected):
     'tokens, expected',
     [
         ([], []),
+        (['B'], [('_', 0, 1)]),
+        (['I'], []),
+        (['O'], []),
+        (['O', 'O'], []),
+        (['O', 'I'], []),
+        (['O', 'B'], [('_', 1, 2)]),
+        (['I', 'O'], []),
+        (['I', 'I'], []),
+        (['I', 'B'], [('_', 1, 2)]),
+        (['B', 'O'], [('_', 0, 1)]),
+        (['B', 'I'], [('_', 0, 2)]),
+        (['B', 'B'], [('_', 0, 1), ('_', 1, 2)])
+    ]
+)
+def test_iob2_tokens_without_tag(tokens, expected):
+    tokens = Tokens(tokens, IOB2)
+    entities = tokens.entities
+    assert entities == expected
+
+
+@pytest.mark.parametrize(
+    'tokens, expected',
+    [
+        ([], []),
         (['E-PER'], []),
         (['I-PER'], [('PER', 0, 1)]),
         (['O'], []),
@@ -284,6 +308,30 @@ def test_ioe2_tokens(tokens, expected):
 @pytest.mark.parametrize(
     'tokens, expected',
     [
+        ([], []),
+        (['E'], [('_', 0, 1)]),
+        (['I'], []),
+        (['O'], []),
+        (['O', 'O'], []),
+        (['O', 'I'], []),
+        (['O', 'E'], [('_', 1, 2)]),
+        (['I', 'O'], []),
+        (['I', 'I'], []),
+        (['I', 'E'], [('_', 0, 2)]),
+        (['E', 'O'], [('_', 0, 1)]),
+        (['E', 'I'], [('_', 0, 1)]),
+        (['E', 'E'], [('_', 0, 1), ('_', 1, 2)])
+    ]
+)
+def test_ioe2_tokens_without_tag(tokens, expected):
+    tokens = Tokens(tokens, IOE2)
+    entities = tokens.entities
+    assert entities == expected
+
+
+@pytest.mark.parametrize(
+    'tokens, expected',
+    [
         (['O'], []),
         (['I-PER'], []),
         (['B-PER'], []),
@@ -304,6 +352,7 @@ def test_ioe2_tokens(tokens, expected):
         (['B-PER', 'O'], []),
         (['B-PER', 'I-PER'], []),
         (['B-PER', 'I-ORG'], []),
+        (['B-PER', 'B-PER'], []),
         (['B-PER', 'E-PER'], [('PER', 0, 2)]),
         (['B-PER', 'E-ORG'], []),
         (['B-PER', 'S-PER'], [('PER', 1, 2)]),
@@ -320,6 +369,47 @@ def test_ioe2_tokens(tokens, expected):
     ]
 )
 def test_iobes_tokens(tokens, expected):
+    tokens = Tokens(tokens, IOBES)
+    entities = tokens.entities
+    assert entities == expected
+
+
+@pytest.mark.parametrize(
+    'tokens, expected',
+    [
+        (['O'], []),
+        (['I'], []),
+        (['B'], []),
+        (['E'], []),
+        (['S'], [('_', 0, 1)]),
+        (['O', 'O'], []),
+        (['O', 'I'], []),
+        (['O', 'B'], []),
+        (['O', 'E'], []),
+        (['O', 'S'], [('_', 1, 2)]),
+        (['I', 'O'], []),
+        (['I', 'I'], []),
+        (['I', 'B'], []),
+        (['I', 'E'], []),
+        (['I', 'S'], [('_', 1, 2)]),
+        (['B', 'O'], []),
+        (['B', 'I'], []),
+        (['B', 'B'], []),
+        (['B', 'E'], [('_', 0, 2)]),
+        (['B', 'S'], [('_', 1, 2)]),
+        (['E', 'O'], []),
+        (['E', 'I'], []),
+        (['E', 'B'], []),
+        (['E', 'E'], []),
+        (['E', 'S'], [('_', 1, 2)]),
+        (['S', 'O'], [('_', 0, 1)]),
+        (['S', 'I'], [('_', 0, 1)]),
+        (['S', 'B'], [('_', 0, 1)]),
+        (['S', 'E'], [('_', 0, 1)]),
+        (['S', 'S'], [('_', 0, 1), ('_', 1, 2)])
+    ]
+)
+def test_iobes_tokens_without_tag(tokens, expected):
     tokens = Tokens(tokens, IOBES)
     entities = tokens.entities
     assert entities == expected


### PR DESCRIPTION
The current version is designed to implement `conlleval.pl` in Python. However, in some cases(#25, #23) the analysis is ambiguous.

By using the newly created scheme classes, analysis can be performed without ambiguity. Currently, the following five schemas are supported. IOE1 still needs to be fixed.

- IOB1
- IOB2
- IOE1
- IOE2
- IOBES

```python
>>> from seqeval.scheme import IOB1, IOB2, IOBES, Tokens, auto_detect
>>> # valid tokens as IOB1.
>>> Tokens(['I-PER', 'I-PER', 'O'], IOB1).entities
[('PER', 0, 2)]
>>> # invalid tokens as IOB2
>>> Tokens(['I-PER', 'I-PER', 'O'], IOB2).entities
[]
>>> # strict analysis.
>>> Tokens(['B-PER', 'I-PER', 'S-PER'], IOBES).entities
[('PER', 2, 3)]
>>> # detect scheme automatically.
>>> auto_detect([['B-PER', 'I-PER', 'E-PER', 'S-PER']])
<class 'seqeval.scheme.IOBES'>
```
