### PR TITLE
Add length check to classification_report v1

### DIFF
--- a/seqeval/metrics/v1.py
+++ b/seqeval/metrics/v1.py
@@ -92,8 +92,11 @@ def check_consistent_length(y_true: List[List[str]], y_pred: List[List[str]]):
     """
     len_true = list(map(len, y_true))
     len_pred = list(map(len, y_pred))
-    is_list = set(map(type, y_true + y_pred))
-    if len(y_true) != len(y_pred) or len_true != len_pred or not is_list == {list}:
+    is_list = set(map(type, y_true)) | set(map(type, y_pred))
+    if not is_list == {list}:
+        raise TypeError('Found input variables without list of list.')
+
+    if len(y_true) != len(y_pred) or len_true != len_pred:
         message = 'Found input variables with inconsistent numbers of samples:\n{}\n{}'.format(len_true, len_pred)
         raise ValueError(message)
 
@@ -338,6 +341,8 @@ def classification_report(y_true: List[List[str]],
        weighted avg       0.50      0.50      0.50         2
         <BLANKLINE>
     """
+    check_consistent_length(y_true, y_pred)
+
     if scheme is None or not issubclass(scheme, Token):
         scheme = auto_detect(y_true, suffix)
     target_names = unique_labels(y_true, y_pred, scheme, suffix)

--- a/tests/test_v1.py
+++ b/tests/test_v1.py
@@ -4,7 +4,7 @@ from sklearn.exceptions import UndefinedMetricWarning
 from sklearn.utils._testing import (assert_array_almost_equal,
                                     assert_array_equal)
 
-from seqeval.metrics.v1 import (classification_report,
+from seqeval.metrics.v1 import (check_consistent_length, classification_report,
                                 precision_recall_fscore_support, unique_labels)
 from seqeval.scheme import IOB2
 
@@ -24,6 +24,43 @@ from seqeval.scheme import IOB2
 def test_unique_labels(y_true, y_pred, expected):
     labels = unique_labels(y_true, y_pred, IOB2)
     assert labels == expected
+
+
+class TestCheckConsistentLength:
+
+    @pytest.mark.parametrize(
+        'y_true, y_pred',
+        [
+            ([[]], [[]]),
+            ([['B']], [['B']])
+        ]
+    )
+    def test_check_valid_list(self, y_true, y_pred):
+        check_consistent_length(y_true, y_pred)
+
+    @pytest.mark.parametrize(
+        'y_true, y_pred',
+        [
+            ([()], [()]),
+            (np.array([[]]), np.array([[]])),
+            (np.array([[]]), [[]])
+        ]
+    )
+    def test_check_invalid_type(self, y_true, y_pred):
+        with pytest.raises(TypeError):
+            check_consistent_length(y_true, y_pred)
+
+    @pytest.mark.parametrize(
+        'y_true, y_pred',
+        [
+            ([[]], [['B']]),
+            ([['B'], []], [['B']]),
+            ([['B'], []], [['B'], ['I']])
+        ]
+    )
+    def test_invalid_length(self, y_true, y_pred):
+        with pytest.raises(ValueError):
+            check_consistent_length(y_true, y_pred)
 
 
 class TestPrecisionRecallFscoreSupport:
@@ -100,6 +137,30 @@ class TestPrecisionRecallFscoreSupport:
 
 
 class TestClassificationReport:
+
+    @pytest.mark.parametrize(
+        'y_true, y_pred',
+        [
+            ([()], [()]),
+            (np.array([[]]), np.array([[]])),
+            (np.array([[]]), [[]])
+        ]
+    )
+    def test_check_invalid_type(self, y_true, y_pred):
+        with pytest.raises(TypeError):
+            check_consistent_length(y_true, y_pred)
+
+    @pytest.mark.parametrize(
+        'y_true, y_pred',
+        [
+            ([[]], [['B']]),
+            ([['B'], []], [['B']]),
+            ([['B'], []], [['B'], ['I']])
+        ]
+    )
+    def test_invalid_length(self, y_true, y_pred):
+        with pytest.raises(ValueError):
+            check_consistent_length(y_true, y_pred)
 
     def test_output_dict(self):
         y_true = [['B-A', 'B-B', 'O', 'B-A']]


### PR DESCRIPTION
# Description

Add `check_consistent length` to the top of `classification_report` in v1.

Related to #58 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Enhancement

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] TestCheckConsistentLength
- [x] TestClassificationReport

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
