### PR TITLE
make beta an optional parameter for f1_score function

### DIFF
--- a/seqeval/metrics/sequence_labeling.py
+++ b/seqeval/metrics/sequence_labeling.py
@@ -281,7 +281,8 @@ def f1_score(y_true: List[List[str]], y_pred: List[List[str]],
              mode: Optional[str] = None,
              sample_weight: Optional[List[int]] = None,
              zero_division: str = 'warn',
-             scheme: Optional[Type[Token]] = None):
+             scheme: Optional[Type[Token]] = None, 
+             beta: float = 1.0):
     """Compute the F1 score.
 
     The F1 score can be interpreted as a weighted average of the precision and
@@ -329,6 +330,9 @@ def f1_score(y_true: List[List[str]], y_pred: List[List[str]],
         scheme : Token, [IOB2, IOE2, IOBES]
 
         suffix : bool, False by default.
+        
+        beta : float, 1.0 by default
+            The strength of recall versus precision in the F-score.
 
     Returns:
         score : float or array of float, shape = [n_unique_labels].
@@ -350,7 +354,7 @@ def f1_score(y_true: List[List[str]], y_pred: List[List[str]],
         _, _, f, _ = precision_recall_fscore_support_v1(y_true, y_pred,
                                                         average=average,
                                                         warn_for=('f-score',),
-                                                        beta=1,
+                                                        beta=beta,
                                                         sample_weight=sample_weight,
                                                         zero_division=zero_division,
                                                         scheme=scheme,
@@ -359,7 +363,7 @@ def f1_score(y_true: List[List[str]], y_pred: List[List[str]],
         _, _, f, _ = precision_recall_fscore_support(y_true, y_pred,
                                                      average=average,
                                                      warn_for=('f-score',),
-                                                     beta=1,
+                                                     beta=beta,
                                                      sample_weight=sample_weight,
                                                      zero_division=zero_division,
                                                      suffix=suffix)


### PR DESCRIPTION
# Description

Functions used inside f1_score function use `beta` as a parameter. However, f1_score function itself doesn't give the opportunity to change the balance between precision and recall. It could be a nice little feature to allow users have control over this parameter.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

The parameter doesn't change anything under the hood and can't affect other functionality

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
