### PR TITLE
Add pyproject.toml declaring setuptools as build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ required = ['numpy>=1.14.0', 'scikit-learn>=0.21.3']
 setup(
     name=NAME,
     use_scm_version=True,
-    setup_requires=['setuptools_scm'],
     description=DESCRIPTION,
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
# Description

This changeset adds a minimal `pyproject.toml` to the project, bringing it into line with [PEP 517](https://peps.python.org/pep-0517/) and making it harder to build the project in an environment with incompatible versions of `setuptools` and `setuptools-scm`, as these packages will be installed together as part of the `build-requires` in the isolated build environment.

Fixes #110

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] After adding this file, the project can be successfully built/installed by the same virtual environment and `pip install` invocation as listed in #110.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
